### PR TITLE
部署、役職の区切りを示す「,」を表示する条件の修正

### DIFF
--- a/app/views/admin/entries/_entries.html.erb
+++ b/app/views/admin/entries/_entries.html.erb
@@ -18,7 +18,7 @@
       <tr id="entry-<%= entry.id %>">
       <td><%= entry.updated_at.strftime("%Y/%m/%d") %></td>
       <td><%= entry.company %></td>
-      <td><%= entry.division %><%= ",  " if entry.division.present? %><%= entry.position %></td>
+      <td><%= entry.division %><%= ",  " if entry.division.present? && entry.position.present? %><%= entry.position %></td>
       <td><%= entry.name %></td>
       <td><%= entry.phone %></td>
       <td><%= mail_to entry.email, entry.email %></td>

--- a/app/views/admin/entries/_entries.html.erb
+++ b/app/views/admin/entries/_entries.html.erb
@@ -19,6 +19,7 @@
       <td><%= entry.updated_at.strftime("%Y/%m/%d") %></td>
       <td><%= entry.company %></td>
       <td><%= entry.division %><%= ",  " if entry.division.present? && entry.position.present? %><%= entry.position %></td>
+      <td><%= [entry.division, entry.position].select(&:present?).join(",  ") %></td>
       <td><%= entry.name %></td>
       <td><%= entry.phone %></td>
       <td><%= mail_to entry.email, entry.email %></td>

--- a/app/views/admin/entries/_entries.html.erb
+++ b/app/views/admin/entries/_entries.html.erb
@@ -18,7 +18,6 @@
       <tr id="entry-<%= entry.id %>">
       <td><%= entry.updated_at.strftime("%Y/%m/%d") %></td>
       <td><%= entry.company %></td>
-      <td><%= entry.division %><%= ",  " if entry.division.present? && entry.position.present? %><%= entry.position %></td>
       <td><%= [entry.division, entry.position].select(&:present?).join(",  ") %></td>
       <td><%= entry.name %></td>
       <td><%= entry.phone %></td>


### PR DESCRIPTION
以下の対応です。
- #6 [部署・役職名]欄に不要な「,」が表示されている
